### PR TITLE
Update price rounding method

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -9,8 +9,7 @@ class Product < ApplicationRecord
   end
 
   def total_price
-    amount = unit_price + sales_tax
-    Helpers::PriceHelper.round amount
+    unit_price + sales_tax
   end
 
   def self.import_from_csv(csv_file)

--- a/lib/helpers/price_helper.rb
+++ b/lib/helpers/price_helper.rb
@@ -1,10 +1,11 @@
 module Helpers
   class PriceHelper
-    DEFAULT_ROUNDED_DIGITS = 2
+    DEFAULT_ROUND_TO_NEAREST = 0.01
     DEFAULT_DISPLAYED_DIGITS = 2
 
-    def self.round(amount, number_of_digits = DEFAULT_ROUNDED_DIGITS)
-      amount.round(number_of_digits)
+    def self.round(amount, round_to_nearest = DEFAULT_ROUND_TO_NEAREST)
+      scale = 1 / round_to_nearest
+      (amount * scale).round / scale
     end
 
     def self.display(amount, number_of_digits = DEFAULT_DISPLAYED_DIGITS)

--- a/lib/helpers/price_helper.rb
+++ b/lib/helpers/price_helper.rb
@@ -1,6 +1,6 @@
 module Helpers
   class PriceHelper
-    DEFAULT_ROUND_TO_NEAREST = 0.01
+    DEFAULT_ROUND_TO_NEAREST = 0.05
     DEFAULT_DISPLAYED_DIGITS = 2
 
     def self.round(amount, round_to_nearest = DEFAULT_ROUND_TO_NEAREST)

--- a/spec/fixtures/output2.csv
+++ b/spec/fixtures/output2.csv
@@ -1,4 +1,4 @@
 1,imported box of chocolates,10.50
-1,imported bottle of perfume,54.63
-Sales Taxes: 7.63
-Total: 65.13
+1,imported bottle of perfume,54.65
+Sales Taxes: 7.65
+Total: 65.15

--- a/spec/fixtures/output3.csv
+++ b/spec/fixtures/output3.csv
@@ -1,6 +1,6 @@
 1,imported bottle of perfume,32.19
 1,bottle of perfume,20.89
 1,packet of headache pills,9.75
-1,box of imported chocolates,11.81
-Sales Taxes: 6.66
-Total: 74.64
+1,box of imported chocolates,11.80
+Sales Taxes: 6.65
+Total: 74.63

--- a/spec/models/dosmetic_product_spec.rb
+++ b/spec/models/dosmetic_product_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe DosmeticProduct, type: :model do
     let!(:dosmetic_product) { create(:dosmetic_product, unit_price: 15.25) }
 
     it 'should be 10% of unit price rounded up to 2 digits' do
-      expect(dosmetic_product.sales_tax).to eq(1.53)
+      expect(dosmetic_product.sales_tax).to eq(1.55)
     end
   end
 end

--- a/spec/models/receipt_spec.rb
+++ b/spec/models/receipt_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Receipt, type: :model do
         Product.import_from_csv(input2_path)
       end
 
-      it 'should return output1' do
+      it 'should return output2' do
         Receipt.csv_transform input2_path, csv_out_name
 
         actual_csv = CSV.read(csv_out_path)
@@ -51,7 +51,7 @@ RSpec.describe Receipt, type: :model do
         Product.import_from_csv(input3_path)
       end
 
-      it 'should return output1' do
+      it 'should return output3' do
         Receipt.csv_transform input3_path, csv_out_name
 
         actual_csv = CSV.read(csv_out_path)


### PR DESCRIPTION
- Update rounding method using nearest precision instead of number of digits
- Update test accordingly
- Remove total price rounding up (because it's not in the requirement)